### PR TITLE
Listen recursively to directories

### DIFF
--- a/amqp-pathwatcher.cabal
+++ b/amqp-pathwatcher.cabal
@@ -21,4 +21,5 @@ executable amqp-pathwatcher
                      , directory
                      , filepath
                      , text
+                     , unix
   default-language:    Haskell2010


### PR DESCRIPTION
Upon startup, amqp-pathwatcher will now find nested directories in the
incomingPath and set up a separate inotify watcher for each one.

Fixes BAT-409
